### PR TITLE
Removed handling float32 on Rat.Scan()

### DIFF
--- a/type.go
+++ b/type.go
@@ -33,8 +33,6 @@ func (rat *Rat) Scan(src interface{}) (err error) {
 		_, err = fmt.Sscan(t, rat.Rat)
 	case []byte:
 		_, err = fmt.Sscan(string(t), rat.Rat)
-	case float32:
-		rat.Rat.SetFloat64(float64(t))
 	case float64:
 		rat.Rat.SetFloat64(t)
 	default:


### PR DESCRIPTION
sql.Scanner.Scan() is not receive float32.
reference : http://golang.org/pkg/database/sql/#Scanner

So, I removed handling code on this PR.

thank you!
