### PR TITLE
Fix argument for append. append breaks slice it-self.

### DIFF
--- a/genmai.go
+++ b/genmai.go
@@ -726,7 +726,7 @@ func (db *DB) collectFieldIndexes(typ reflect.Type, index []int) (indexes [][]in
 			continue
 		}
 		if !(db.hasSkipTag(&field) || (db.hasPKTag(&field) && db.isAutoIncrementable(&field))) {
-			tmp := make([]int, len(index))
+			tmp := make([]int, len(index)+1)
 			copy(tmp, index)
 			tmp = append(tmp, i)
 			if field.Anonymous {


### PR DESCRIPTION
構造体を内包する場合、再起呼び出しを行いますが append は第一引数を破壊するので、つまりは呼び出し元の引数をコピーして使う必要があります。
cap の状態によっては同じ slice だったり、コピーになったりする事でうまく動いたり(linux)、動かなかったり(windows)するのはその為だと思います。
