### PR TITLE
Fix error when call In() by Slice or Array.

### DIFF
--- a/genmai.go
+++ b/genmai.go
@@ -1120,6 +1120,30 @@ func (c *Condition) Or(cond interface{}, args ...interface{}) *Condition {
 
 // In adds "IN" clause to the Condition and returns it for method chain.
 func (c *Condition) In(args ...interface{}) *Condition {
+	if len(args) > 0 {
+		if k := reflect.TypeOf(args[0]).Kind(); k == reflect.Slice || k == reflect.Array {
+			v := reflect.ValueOf(args[0])
+			if len := v.Len(); len > 0 {
+
+				k := v.Index(0).Kind()
+				na := make([]interface{}, len)
+
+				for i := 0; i < len; i++ {
+					switch k {
+					case reflect.String:
+						na[i] = v.Index(i).String()
+					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+						na[i] = v.Index(i).Int()
+					case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+						na[i] = v.Index(i).Uint()
+					case reflect.Float32, reflect.Float64:
+						na[i] = v.Index(i).Float()
+					}
+				}
+				return c.appendQuery(100, In, na)
+			}
+		}
+	}
 	return c.appendQuery(100, In, args)
 }
 

--- a/genmai_test.go
+++ b/genmai_test.go
@@ -422,7 +422,41 @@ func Test_Select(t *testing.T) {
 		}
 	}()
 
-	// SELECT * FROM test_model WHERE "name" LIKE "%3";
+    // SELECT * FROM test_model WHERE "id" IN (2, 3) (by slice);
+    func() {
+        db := newTestDB(t)
+        defer db.Close()
+        var actual []testModel
+        cond := []int32{2,3}
+        if err := db.Select(&actual, db.Where("id").In(cond)); err != nil {
+            t.Fatal(err)
+        }
+        expected := []testModel{
+            {2, "test2", "addr2"}, {3, "test3", "addr3"},
+        }
+        if !reflect.DeepEqual(actual, expected) {
+            t.Errorf("Expect %v, but %v", expected, actual)
+        }
+    }()
+
+    // SELECT * FROM test_model WHERE "id" IN (2, 3) (by array);
+    func() {
+        db := newTestDB(t)
+        defer db.Close()
+        var actual []testModel
+        cond := [2]int32{2,3}
+        if err := db.Select(&actual, db.Where("id").In(cond)); err != nil {
+            t.Fatal(err)
+        }
+        expected := []testModel{
+            {2, "test2", "addr2"}, {3, "test3", "addr3"},
+        }
+        if !reflect.DeepEqual(actual, expected) {
+            t.Errorf("Expect %v, but %v", expected, actual)
+        }
+    }()
+
+    // SELECT * FROM test_model WHERE "name" LIKE "%3";
 	func() {
 		db := newTestDB(t)
 		defer db.Close()


### PR DESCRIPTION
When call In() by slice or array(like []int32{2,3} or [2]int{2,3}), args of In() becomes single entry slice of slice(like [[2,3]]).
Then placeholder for SQL IN clause have only one entry  "(?)"  and slice can't convert to correct SQL literal.
It causes SQL error.
