### PR TITLE
Specify join target table

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,22 @@ if err := db.Begin(); err != nil {
 // do something.
 ```
 
+### Using any table name
+
+You can implement [TableNamer](https://godoc.org/github.com/naoina/genmai#TableNamer) interface to use any table name.
+
+```go
+type UserTable struct {
+    Id int64 `db:"pk"`
+}
+
+func (u *UserTable) TableName() string {
+    return "user"
+}
+```
+
+In the above example, the table name `user` is used instead of `user_table`.
+
 ### Using raw database/sql interface
 
 ```go

--- a/genmai.go
+++ b/genmai.go
@@ -1120,6 +1120,30 @@ func (c *Condition) Or(cond interface{}, args ...interface{}) *Condition {
 
 // In adds "IN" clause to the Condition and returns it for method chain.
 func (c *Condition) In(args ...interface{}) *Condition {
+	if len(args) > 0 {
+		if k := reflect.TypeOf(args[0]).Kind(); k == reflect.Slice || k == reflect.Array {
+			v := reflect.ValueOf(args[0])
+			if len := v.Len(); len > 0 {
+
+				k := v.Index(0).Kind()
+				na := make([]interface{}, len)
+
+				for i := 0; i < len; i++ {
+					switch k {
+					case reflect.String:
+						na[i] = v.Index(i).String()
+					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+						na[i] = v.Index(i).Int()
+					case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+						na[i] = v.Index(i).Uint()
+					case reflect.Float32, reflect.Float64:
+						na[i] = v.Index(i).Float()
+					}
+				}
+				return c.appendQuery(100, In, na)
+			}
+		}
+	}
 	return c.appendQuery(100, In, args)
 }
 

--- a/genmai_test.go
+++ b/genmai_test.go
@@ -422,7 +422,41 @@ func Test_Select(t *testing.T) {
 		}
 	}()
 
-	// SELECT * FROM test_model WHERE "name" LIKE "%3";
+    // SELECT * FROM test_model WHERE "id" IN (2, 3) (by slice);
+    func() {
+        db := newTestDB(t)
+        defer db.Close()
+        var actual []testModel
+        cond := []int32{2,3}
+        if err := db.Select(&actual, db.Where("id").In(cond)); err != nil {
+            t.Fatal(err)
+        }
+        expected := []testModel{
+            {2, "test2", "addr2"}, {3, "test3", "addr3"},
+        }
+        if !reflect.DeepEqual(actual, expected) {
+            t.Errorf("Expect %v, but %v", expected, actual)
+        }
+    }()
+
+    // SELECT * FROM test_model WHERE "id" IN (2, 3) (by array);
+    func() {
+        db := newTestDB(t)
+        defer db.Close()
+        var actual []testModel
+        cond := [2]int32{2,3}
+        if err := db.Select(&actual, db.Where("id").In(cond)); err != nil {
+            t.Fatal(err)
+        }
+        expected := []testModel{
+            {2, "test2", "addr2"}, {3, "test3", "addr3"},
+        }
+        if !reflect.DeepEqual(actual, expected) {
+            t.Errorf("Expect %v, but %v", expected, actual)
+        }
+    }()
+
+    // SELECT * FROM test_model WHERE "name" LIKE "%3";
 	func() {
 		db := newTestDB(t)
 		defer db.Close()

--- a/genmai_test.go
+++ b/genmai_test.go
@@ -43,6 +43,30 @@ type M2 struct {
 	Body string
 }
 
+type joinTestModel struct {
+	Id       int64
+	PersonId int64
+	AddrId   int64
+}
+
+type jTModelM2Rel struct {
+	Id          int64
+	TestModelId int64
+	M2Id        int64
+}
+
+type joinPerson struct {
+	Id   int64
+	Name string
+	Age  int64
+}
+
+type joinAddr struct {
+	Id     int64
+	Addr   string
+	Nation string
+}
+
 type TestModelForHook struct {
 	Id        int64 `db:"pk"`
 	Name      string
@@ -183,6 +207,47 @@ func newDifferentTestDB(t *testing.T) *DB {
 		`INSERT INTO diff_table (id, name, addr) VALUES (7, 'diff_dup', 'diff_dup_addr');`,
 		`INSERT INTO diff_table (id, name, addr) VALUES (8, 'diff_other1', 'diff_addr8');`,
 		`INSERT INTO diff_table (id, name, addr) VALUES (9, 'diff_other2', 'diff_addr9');`,
+	} {
+		if _, err := db.db.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return db
+}
+
+func multiJoinTestDB(t *testing.T) *DB {
+	db, err := testDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, query := range []string{
+		`DROP TABLE IF EXISTS join_person`,
+		createTableString("join_person", "name text not null", "age integer not null"),
+		`INSERT INTO join_person (id, name, age) VALUES (1, 'Taro', 25);`,
+		`INSERT INTO join_person (id, name, age) VALUES (2, 'Tama', 2);`,
+		`INSERT INTO join_person (id, name, age) VALUES (3, 'Mike', 34);`,
+		`INSERT INTO join_person (id, name, age) VALUES (4, 'Hanako', 24);`,
+		`DROP TABLE IF EXISTS join_addr`,
+		createTableString("join_addr", "addr text not null", "nation varchar not null"),
+		`INSERT INTO join_addr (id, addr, nation) VALUES (1, 'Tokyo', 'Japan');`,
+		`INSERT INTO join_addr (id, addr, nation) VALUES (2, 'Frisco', 'US');`,
+		`DROP TABLE IF EXISTS join_test_model`,
+		createTableString("join_test_model", "person_id integer not null", "addr_id integer not null"),
+		`INSERT INTO join_test_model (id, person_id, addr_id) VALUES (1, 1, 1);`,
+		`INSERT INTO join_test_model (id, person_id, addr_id) VALUES (2, 2, 1);`,
+		`INSERT INTO join_test_model (id, person_id, addr_id) VALUES (3, 3, 2);`,
+		`INSERT INTO join_test_model (id, person_id, addr_id) VALUES (4, 4, 1);`,
+		`DROP TABLE IF EXISTS m2`,
+		createTableString("m2", "body text not null"),
+		`INSERT INTO m2 (id, body) VALUES (1, 'a1');`,
+		`INSERT INTO m2 (id, body) VALUES (2, 'b2');`,
+		`DROP TABLE IF EXISTS j_t_model_m2_rel`,
+		createTableString("j_t_model_m2_rel", "j_t_model_id integer not null", "m2_id integer not null"),
+		`INSERT INTO j_t_model_m2_rel (id, j_t_model_id, m2_id) VALUES (1, 1, 1);`,
+		`INSERT INTO j_t_model_m2_rel (id, j_t_model_id, m2_id) VALUES (2, 2, 1);`,
+		`INSERT INTO j_t_model_m2_rel (id, j_t_model_id, m2_id) VALUES (3, 3, 1);`,
+		`INSERT INTO j_t_model_m2_rel (id, j_t_model_id, m2_id) VALUES (4, 1, 2);`,
+		`INSERT INTO j_t_model_m2_rel (id, j_t_model_id, m2_id) VALUES (5, 2, 2);`,
 	} {
 		if _, err := db.db.Exec(query); err != nil {
 			t.Fatal(err)
@@ -739,6 +804,44 @@ func Test_Select(t *testing.T) {
 		}
 		expected := []testModel{
 			{2, "test2", "addr2"},
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Expect %v, but %v", expected, actual)
+		}
+	}()
+
+	// SELECT "join_test_model".* FROM "join_test_model" JOIN "join_addr" ON "join_test_model"."addr_id" = "join_addr"."id" JOIN "join_person" ON "join_test_model"."person_id" = "join_person"."id" WHERE "join_addr"."nation" = "Japan" AND "join_person"."age" > 20?;
+	func() {
+		db := multiJoinTestDB(t)
+		defer db.Close()
+		var actual []joinTestModel
+		t2 := &joinAddr{}
+		t3 := &joinPerson{}
+		if err := db.Select(&actual, db.Join(t2).On("addr_id", "=", "id"), db.Join(t3).On("person_id", "=", "id"), db.Where(t2, "nation", "=", "Japan").And(t3, "age", ">", 20)); err != nil {
+			t.Fatal(err)
+		}
+		expected := []joinTestModel{
+			{1, 1, 1},
+			{4, 4, 1},
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Expect %v, but %v", expected, actual)
+		}
+	}()
+
+	// SELECT "join_test_model".* FROM "join_test_model" JOIN "j_t_model_m2_rel" ON "join_test_model"."id" = "j_t_model_m2_rel"."j_t_model_id" JOIN "m2" ON "j_t_model_m2_rel"."m2_id" = "m2"."id" WHERE "m2"."id" = 2;
+	func() {
+		db := multiJoinTestDB(t)
+		defer db.Close()
+		var actual []joinTestModel
+		t2 := &M2{}
+		tr := &jTModelM2Rel{}
+		if err := db.Select(&actual, db.Join(tr).On("id", "=", "j_t_model_id"), db.Join(t2).On(tr, "m2_id", "=", "id"), db.Where(t2, "id", "=", 2)); err != nil {
+			t.Fatal(err)
+		}
+		expected := []joinTestModel{
+			{1, 1, 1},
+			{2, 2, 1},
 		}
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("Expect %v, but %v", expected, actual)


### PR DESCRIPTION
func On() can specify only column name to join parameter.
Bu there are some cases that need to specify join target table. 

Then I make first parameter of func On() as table specification ( like func Where() )