### PR TITLE
Add not_ai tag

### DIFF
--- a/genmai.go
+++ b/genmai.go
@@ -812,6 +812,11 @@ func (db *DB) hasPKTag(field *reflect.StructField) bool {
 
 // isAutoIncrementable returns whether the struct field is integer.
 func (db *DB) isAutoIncrementable(field *reflect.StructField) bool {
+	for _, tag := range db.tagsFromField(field) {
+		if tag == "not_ai" {
+			return false
+		}
+	}
 	switch field.Type.Kind() {
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:


### PR DESCRIPTION
If primarykey is an integer , will be removed also have been included in the structure , I want to directly INSERT an integer value . Use for example, INSERT to a dependent table .

usage:
```SQL
CREATE TABLE `user` (
  `user_id` int(11) NOT NULL AUTO_INCREMENT,
  `username` varchar(64) NOT NULL,
)
CREATE TABLE `user_setting` (
  `user_id` int(11) NOT NULL,
  `some_setting_value` int(11) NOT NULL,
)
```
```Go
type User struct {
	Id         int    `db:"pk" column:"user_id"`
	Username string
}
type UserSetting struct {
	UserId int `db:"pk,not_ai"`
	SomeSettingValue int `db:"pk"`
}

user := &User {
	Username : "USER_NAME",
}
db.Insert(user)
setting := &UserSetting {
	UserId : user.Id,
	SomeSettingValue: 1
}
db.Insert(setting)
```
