### PR TITLE
support GroupBy clause using Grouping columns

### DIFF
--- a/genmai_test.go
+++ b/genmai_test.go
@@ -446,7 +446,7 @@ func Test_Select(t *testing.T) {
 			Name string
 		}
 		var actual []groupedBy
-		if err := db.Select(&actual, "name", db.From(&testModel{}), db.GroupBy("name")); err != nil {
+		if err := db.Select(&actual, "name", db.From(&testModel{}), db.GroupBy("name"), db.OrderBy("name", ASC)); err != nil {
 			t.Fatal(err)
 		}
 		expected := []groupedBy{
@@ -468,13 +468,13 @@ func Test_Select(t *testing.T) {
 			Addr string
 		}
 		var actual []groupedBy
-		if err := db.Select(&actual, []string{"name", "addr"}, db.From(&testModel{}), db.GroupBy("name", "addr")); err != nil {
+		if err := db.Select(&actual, []string{"name", "addr"}, db.From(&testModel{}), db.GroupBy("name", "addr"), db.OrderBy("addr", ASC)); err != nil {
 			t.Fatal(err)
 		}
 		expected := []groupedBy{
-			{"dup", "dup_addr"}, {"other", "addr4"}, {"other", "addr5"},
-			{"other1", "addr8"}, {"other2", "addr9"},
-			{"test1", "addr1"}, {"test2", "addr2"}, {"test3", "addr3"},
+			{"test1", "addr1"}, {"test2", "addr2"}, {"test3", "addr3"}, {"other", "addr4"},
+			{"other", "addr5"}, {"other1", "addr8"}, {"other2", "addr9"},
+			{"dup", "dup_addr"},
 		}
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("Expect %v, but %v", expected, actual)
@@ -494,13 +494,13 @@ func Test_Select(t *testing.T) {
 		grouping := Grouping{
 			columns: []string{"name", "addr"},
 		}
-		if err := db.Select(&actual, &grouping, db.From(table), db.GroupBy(table, "name", "addr")); err != nil {
+		if err := db.Select(&actual, &grouping, db.From(table), db.GroupBy(table, "name", "addr"), db.OrderBy("addr", ASC)); err != nil {
 			t.Fatal(err)
 		}
 		expected := []groupedBy{
-			{"dup", "dup_addr"}, {"other", "addr4"}, {"other", "addr5"},
-			{"other1", "addr8"}, {"other2", "addr9"},
-			{"test1", "addr1"}, {"test2", "addr2"}, {"test3", "addr3"},
+			{"test1", "addr1"}, {"test2", "addr2"}, {"test3", "addr3"}, {"other", "addr4"},
+			{"other", "addr5"}, {"other1", "addr8"}, {"other2", "addr9"},
+			{"dup", "dup_addr"},
 		}
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("Expect %v, but %v", expected, actual)
@@ -526,7 +526,7 @@ func Test_Select(t *testing.T) {
 				},
 			},
 		}
-		if err := db.Select(&actual, &grouping, db.From(&testModel{}), db.GroupBy("name")); err != nil {
+		if err := db.Select(&actual, &grouping, db.From(&testModel{}), db.GroupBy("name"), db.OrderBy("name", ASC)); err != nil {
 			t.Fatal(err)
 		}
 		expected := []groupedBy{


### PR DESCRIPTION
I implemented _GROUP BY_ clause referring _ORDER BY_ clause.

To be useful with GroupBy, I think we need to give the built in function in sql with columns. genmai already expose Function struct, so I added Grouping struct to be able to use it with grouping columns.

I'm not sure genmai design, I need review and help.

* should I add general _AS_ clause?

I added the feature to Function struct to be able to rename column name for minimum impacts. If genmai should support general _AS_ clause, I will add the feature before GroupBy. What do you think?

```go
type Function struct {
	...

	// alias name (optional).
	As string
}
```

* which is the priority number appropriate?

I just set 300 as same as OrderBy.

```go
	return c.appendQuery(300, GroupBy, groupbys)
```